### PR TITLE
移除 chmod 777 /root 修复路由 SSH 密钥登录间歇性失效的 Bug

### DIFF
--- a/source_codes/lz/func/lz_rule_func.sh
+++ b/source_codes/lz/func/lz_rule_func.sh
@@ -1885,7 +1885,7 @@ fix_hsts_perm() {
     ls -l "\${hsts_file}" | grep -q "^-rw-------" || chmod 600 "\${hsts_file}" 2>/dev/null
 }
 
-chmod 777 /root
+chmod 700 /root
 fix_hsts_perm
 
 if [ "\${dl_succeed}" = "1" ]; then


### PR DESCRIPTION
作者大大你好，之前在排查路由器间歇性无法通过 SSH 密钥登录的问题时，追踪发现脚本在更新数据时存在一处不当的权限修改：具体是因为华硕路由的ssh后端 dropbear 会因为检测到/root目录处于777权限而拒绝用户通过ssh密钥登录（但密码可以）由于我自己一直是只开key登录的，前几天遇到登不上就开始查找问题根源，最后锁定你脚本这个问题。你也可以尝试复现一下。